### PR TITLE
Create a scheduler stub

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,12 @@
 compile_commands.json
-/render_worker/build/
 CMakeFiles/
+.cache/
+
+/render_worker/build/
+/render_worker/debug-build/
+/scheduler/build/
+/scheduler/debug-build/
+
 /.worktrees/
-/.cache/
 /docs/
 /CLAUDE.md

--- a/scheduler/CMakeLists.txt
+++ b/scheduler/CMakeLists.txt
@@ -1,0 +1,21 @@
+cmake_minimum_required(VERSION 3.20)
+
+project(pathological-sched)
+
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
+# Find packages
+find_package(CLI11 CONFIG REQUIRED)
+find_package(Drogon CONFIG REQUIRED)
+
+# Main executable
+add_executable(pathological-sched
+    src/main.cpp
+)
+
+target_link_libraries(pathological-sched PRIVATE
+    CLI11::CLI11
+    Drogon::Drogon
+)

--- a/scheduler/CMakePresets.json
+++ b/scheduler/CMakePresets.json
@@ -1,0 +1,22 @@
+{
+  "version": 2,
+  "configurePresets": [
+    {
+      "name": "default",
+      "generator": "Ninja",
+      "binaryDir": "${sourceDir}/build",
+      "cacheVariables": {
+        "CMAKE_TOOLCHAIN_FILE": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake"
+      }
+    },
+    {
+      "name": "debug",
+      "generator": "Ninja",
+      "binaryDir": "${sourceDir}/debug-build",
+      "cacheVariables": {
+        "CMAKE_TOOLCHAIN_FILE": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake",
+	"CMAKE_BUILD_TYPE": "Debug"
+      }
+    }
+  ]
+}

--- a/scheduler/src/main.cpp
+++ b/scheduler/src/main.cpp
@@ -1,0 +1,18 @@
+#include "scheduler.hpp"
+#include <CLI/CLI.hpp>
+
+int main(int argc, char** argv) {
+    CLI::App app{"Pathological Scheduler"};
+
+	bool some_option;
+
+	// Likely options:
+	// - ips/ports to listen on
+	// - database connections
+	// - any config files
+	// - ...
+	app.add_option("someoption", some_option, "Some fake option")->required();
+	CLI11_PARSE(app, argc, argv);
+
+	Scheduler sched{some_option};
+}

--- a/scheduler/src/rpcserver.hpp
+++ b/scheduler/src/rpcserver.hpp
@@ -1,0 +1,4 @@
+// include your grpc headers here...
+
+class GRPCServer {
+};

--- a/scheduler/src/scheduler.hpp
+++ b/scheduler/src/scheduler.hpp
@@ -1,0 +1,13 @@
+#include "rpcserver.hpp"
+#include "webserver.hpp"
+
+class Scheduler {
+public:
+	Scheduler([[maybe_unused]] bool some_option) : rpc_server{}, web_server{} {
+		// Constructor
+	}
+
+private:
+	GRPCServer rpc_server;
+	WebServer web_server;
+};

--- a/scheduler/src/webserver.hpp
+++ b/scheduler/src/webserver.hpp
@@ -1,0 +1,4 @@
+#include <drogon/drogon.h>
+
+class WebServer {
+};

--- a/scheduler/vcpkg-configuration.json
+++ b/scheduler/vcpkg-configuration.json
@@ -1,0 +1,14 @@
+{
+  "default-registry": {
+    "kind": "git",
+    "baseline": "e7b524242c8a5d718a7afa26794c3c19bb8b0c71",
+    "repository": "https://github.com/microsoft/vcpkg"
+  },
+  "registries": [
+    {
+      "kind": "artifact",
+      "location": "https://github.com/microsoft/vcpkg-ce-catalog/archive/refs/heads/main.zip",
+      "name": "microsoft"
+    }
+  ]
+}

--- a/scheduler/vcpkg.json
+++ b/scheduler/vcpkg.json
@@ -1,0 +1,8 @@
+{
+  "name": "pathological-sched",
+  "version": "0.1.0",
+  "dependencies": [
+    "drogon",
+    "cli11"
+  ]
+}


### PR DESCRIPTION
This PR creates a _very_ stubby scheduler. It includes a bare bones cmake/vcpkg project which has drogon (web server) and CLI11 (CLI argument parser). There are a few stubbed c++ source files with no logic included.

resolves #1 