### PR TITLE
fix: replaced 'UNKNOWN' with 'IN_QUEUE' for default constructor

### DIFF
--- a/scheduler/src/renderRequest.cpp
+++ b/scheduler/src/renderRequest.cpp
@@ -2,7 +2,7 @@
 #include <stdexcept>
 
 RenderRequest::RenderRequest()
-    : id(0), status(RenderStatus::UNKNOWN), width(0), height(0),
+    : id(0), status(RenderStatus::IN_QUEUE), width(0), height(0),
       framesPerSecond(0), animationRuntime(0), framesCompleted(0),
       executionTime(0), samplesPerPixel(0) {}
 


### PR DESCRIPTION
* Resolves build issue where default constructor for RenderRequest class contained a deprecated enum.
* Fixes #25 