### PR TITLE
Scheduler queue and renderer connectivity bug fix

### DIFF
--- a/scheduler/src/main.cpp
+++ b/scheduler/src/main.cpp
@@ -9,11 +9,11 @@
 int main(int argc, char **argv) {
     CLI::App app{"Pathological Scheduler"};
 
-    uint16_t grpc_port = 50051;
+    uint16_t grpc_port = 50052;
     std::string listen_address = "0.0.0.0";
     uint16_t http_port = 8080;
 
-    app.add_option("-p,--grpc-port", grpc_port, "Port for gRPC server")->default_val(50051);
+    app.add_option("-p,--grpc-port", grpc_port, "Port for gRPC server")->default_val(50052);
     app.add_option("-a,--address", listen_address, "Address to listen on")->default_val("0.0.0.0");
     app.add_option("--http-port", http_port, "Port for HTTP server")->default_val(8080);
 

--- a/scheduler/src/scheduler.cpp
+++ b/scheduler/src/scheduler.cpp
@@ -63,11 +63,25 @@ void Scheduler::run() {
         {
             std::unique_lock<std::mutex> lock(queue_mutex_);
             job_available_.wait(lock, [this]() {
-                return !pending_jobs_.empty() || !running_;
+                bool has_idle_worker = false;
+                {
+                    std::lock_guard<std::mutex> wlock(workers_mutex_);
+                    for (auto& w : workers_) {
+                        if (w.status == WorkerStatus::IDLE) {
+                            has_idle_worker = true;
+                            break;
+                        }
+                    }
+                }
+                std::cout << "Wait check — jobs: " << pending_jobs_.size() << " | idle worker: " << has_idle_worker << " | running: " << running_ << std::endl;
+                return (!pending_jobs_.empty() && has_idle_worker) || !running_;
             });
         }
         if (!running_) break;
+        assigning_ = true;
         assignJobs();
+        assigning_ = false;
+        job_available_.notify_all();
     }
     std::cout << "Scheduler stopped." << std::endl;
 }
@@ -78,7 +92,8 @@ void Scheduler::stop() {
 }
 
 void Scheduler::assignJobs() {
-    std::lock_guard<std::mutex> lock(workers_mutex_);
+    std::unique_lock<std::mutex> workers_lock(workers_mutex_);
+    std::unique_lock<std::mutex> queue_lock(queue_mutex_);
     std::cout << "Assigning jobs. Queue size: " << pending_jobs_.size()  << " | Connected workers: " << workers_.size() << std::endl;
     while (!pending_jobs_.empty()) {
         Worker* worker = findIdleWorker();
@@ -89,24 +104,33 @@ void Scheduler::assignJobs() {
         RenderRequest job = pending_jobs_.front();
         pending_jobs_.pop();
 
+        std::string worker_id = worker->id;
+        std::string worker_address = worker->ip + ":" + std::to_string(worker->port);
+        worker->status = WorkerStatus::BUSY;
+
+        workers_lock.unlock();
+        queue_lock.unlock();
+
         // This connects to the renderer's gRPC server to send job
+        std::cout << "Dispatching to: " << worker_address << std::endl;
         RenderWorkerClient client(
-            grpc::CreateChannel(
-                worker->ip + ":" + std::to_string(worker->port),
-                grpc::InsecureChannelCredentials()
-            )
+            grpc::CreateChannel(worker_address, grpc::InsecureChannelCredentials())
         );
 
         std::string job_id = client.RenderJob(job);
-        if (job_id != "ERROR") {
-            worker->status = WorkerStatus::BUSY;
-            std::cout << "Job assigned to worker: " << worker->id << " with job ID: " << job_id << std::endl;
-        } else {
-            std::cout << "Job dispatch failed, requeueing." << std::endl;
+        if (job_id == "ERROR") {
+            queue_lock.lock();
             pending_jobs_.push(job);
-            worker->status = WorkerStatus::OFFLINE;
+            queue_lock.unlock();
+
+            workers_lock.lock();
+            Worker* worker_ = findWorkerByID(worker_id);
+            if (worker_) worker_->status = WorkerStatus::OFFLINE;
+            workers_lock.unlock();
             break;
         }
+        workers_lock.lock();
+        queue_lock.lock();
     }
 }
 

--- a/scheduler/src/scheduler.hpp
+++ b/scheduler/src/scheduler.hpp
@@ -54,6 +54,7 @@ private:
 
     // Used to prevent multiple threads from doing shenanigans
     std::atomic<bool> running_{false};
+    std::atomic<bool> assigning_{false};
 
     void assignJobs();
     Worker* findIdleWorker();


### PR DESCRIPTION
Fixed scheduler queue issues regarding worker connectivity and job queue dispatch.

The worker had issues connecting to the scheduler due to mutex issues that have been resolved. There was also a silly issue where the scheduler was listening on the same port as the worker which caused connectivity issues with the mutex as well.

Initially, the worker was only able to accept one job before hanging. This was due to pointer invalidation in the vector list of workers. This was fixed by copying a worker's ip and port into a string to be used for the gRPC connection in scheduler.cpp line 119 instead of using pointers create the channel.