### PR TITLE
RenderStatus Update

### DIFF
--- a/protos/render_server.proto
+++ b/protos/render_server.proto
@@ -32,7 +32,7 @@ message RenderJobResponse {
 
 // Scheduler asks for the status of a given render
 message RenderStatusRequest {
-  int32 job_identifier = 1;
+  string job_identifier = 1;
 }
 
 // Render worker returns status of given render

--- a/render_worker/src/render_server.cpp
+++ b/render_worker/src/render_server.cpp
@@ -26,8 +26,7 @@ Status RenderServer::RenderJob(ServerContext *context, const RenderJobRequest *r
 }
 
 Status RenderServer::RenderStatus(ServerContext *context, const RenderStatusRequest *request, RenderStatusResponse *response) {
-    // Sample implementation
-    response->set_status(render_server::COMPLETED);
+    response->set_status(this->jobs.FetchJobStatus(request->job_identifier()));
     return Status::OK;
 }
 

--- a/scheduler/src/render_client.cpp
+++ b/scheduler/src/render_client.cpp
@@ -28,7 +28,7 @@ std::string RenderWorkerClient::RenderJob(std::shared_ptr<RenderRequest> render)
   }
 }
 
-int RenderWorkerClient::RenderStatus(int job) {
+int RenderWorkerClient::RenderStatus(std::string job) {
   // Data we are sending and getting back
   RenderStatusRequest request;
   RenderStatusResponse response;

--- a/scheduler/src/render_client.hpp
+++ b/scheduler/src/render_client.hpp
@@ -21,7 +21,7 @@ public:
     RenderWorkerClient(std::shared_ptr<Channel> channel) : stub_(RenderWorker::NewStub(channel)) {}
 
     std::string RenderJob(std::shared_ptr<RenderRequest> render);
-    int RenderStatus(int job);
+    int RenderStatus(std::string job);
 
 private:
     std::unique_ptr<RenderWorker::Stub> stub_;


### PR DESCRIPTION
Resolves #55 

RenderStatus now takes in the uuid in form of a string instead of the old int solution. It can now return status of job by referencing this uuid.

Changes made include:
- Changing protofile to reflect string instead of int
- Status response is now set to hold the actual status of a specified job
- Changing render_client to take in string instead of int