### PR TITLE
Render worker AWS upload

### DIFF
--- a/render_worker/src/main.cpp
+++ b/render_worker/src/main.cpp
@@ -1,5 +1,4 @@
 #include "render_server.hpp"
-#include "s3_manager.hpp"
 #include "scheduler_client.hpp"
 
 #include <condition_variable>
@@ -11,12 +10,6 @@
 #include <mutex>
 #include <string>
 #include <thread>
-
-S3Config cfg {
-    .bucketName = "pathological-capstone-s3-bucket",
-    .region = "us-east-2",  // can't use other servers in same region. region must match.
-    .profileName = "default",
-};
 
 // Creating reference to client singleton
 SchedulerClient& client = SchedulerClient::getInstance();
@@ -84,8 +77,7 @@ int main(int argc, char** argv) {
     signal(SIGHUP, signalHandler);  // Probably should change this to just pause process
                                     // but exits for now
 
-    S3Manager manager(cfg);
-    server = BuildServer(renderServerPort, client, worker_id, random_gen, manager);
+    server = BuildServer(renderServerPort, client, worker_id, random_gen);
     std::thread shutdown_thread(shutdownServer);
     server->Wait();
     shutdown_thread.join();

--- a/render_worker/src/main.cpp
+++ b/render_worker/src/main.cpp
@@ -1,4 +1,5 @@
 #include "render_server.hpp"
+#include "s3_manager.hpp"
 #include "scheduler_client.hpp"
 
 #include <condition_variable>
@@ -10,6 +11,12 @@
 #include <mutex>
 #include <string>
 #include <thread>
+
+S3Config cfg {
+    .bucketName = "pathological-capstone-s3-bucket",
+    .region = "us-east-2",  // can't use other servers in same region. region must match.
+    .profileName = "default",
+};
 
 // Creating reference to client singleton
 SchedulerClient& client = SchedulerClient::getInstance();
@@ -77,7 +84,8 @@ int main(int argc, char** argv) {
     signal(SIGHUP, signalHandler);  // Probably should change this to just pause process
                                     // but exits for now
 
-    server = BuildServer(renderServerPort, client, worker_id, random_gen);
+    S3Manager manager(cfg);
+    server = BuildServer(renderServerPort, client, worker_id, random_gen, manager);
     std::thread shutdown_thread(shutdownServer);
     server->Wait();
     shutdown_thread.join();

--- a/render_worker/src/render_server.cpp
+++ b/render_worker/src/render_server.cpp
@@ -1,5 +1,6 @@
 #include "render_server.hpp"
 #include "render_worker.hpp"
+#include "s3_manager.hpp"
 #include "scheduler_client.hpp"
 #include <boost/uuid/random_generator.hpp>
 #include <boost/uuid/uuid_io.hpp>
@@ -10,6 +11,9 @@
 Status RenderServer::RenderJob(ServerContext *context, const RenderJobRequest *request,
     RenderJobResponse *response) {
     std::cout << "Render Recieved" << std::endl;
+    //bool test = this->manager.keyExists("cornell_box_animated.gltf");
+    //std::cout << test << std::endl;
+
     std::shared_ptr<Job> job = std::make_shared<Job>(request->width(), request->height(), request->samples(),
         request->scene_location(), request->output_name(), request->time(), render_server::Status::IN_PROGRESS);
     std::string job_id = boost::uuids::to_string(random_gen());
@@ -31,7 +35,8 @@ Status RenderServer::RenderStatus(ServerContext *context, const RenderStatusRequ
     return Status::OK;
 }
 
-std::unique_ptr<Server> BuildServer(uint16_t port, SchedulerClient& client, std::string worker_id, random_generator rand) {
+std::unique_ptr<Server> BuildServer(uint16_t port, SchedulerClient& client,
+    std::string worker_id, random_generator rand, S3Manager& manager) {
   std::string server_address = absl::StrFormat("0.0.0.0:%d", port);
 
   grpc::EnableDefaultHealthCheckService(true);
@@ -42,7 +47,7 @@ std::unique_ptr<Server> BuildServer(uint16_t port, SchedulerClient& client, std:
 
   // Register "service" as the instance through which we'll communicate with
   // clients.
-  builder.RegisterService(new RenderServer(client, worker_id, rand));
+  builder.RegisterService(new RenderServer(client, worker_id, rand, manager));
 
   // Finally assemble the server.
   std::unique_ptr<Server> server(builder.BuildAndStart());

--- a/render_worker/src/render_server.cpp
+++ b/render_worker/src/render_server.cpp
@@ -7,6 +7,7 @@
 #include <iostream>
 #include <memory>
 #include <string>
+#include <sstream>
 
 S3Config config {
     .bucketName = "pathological-capstone-s3-bucket",
@@ -17,8 +18,6 @@ S3Config config {
 Status RenderServer::RenderJob(ServerContext *context, const RenderJobRequest *request,
     RenderJobResponse *response) {
     std::cout << "Render Recieved" << std::endl;
-    //bool test = this->manager.keyExists("cornell_box_animated.gltf");
-    //std::cout << test << std::endl;
 
     std::shared_ptr<Job> job = std::make_shared<Job>(request->width(), request->height(), request->samples(),
         request->scene_location(), request->output_name(), request->time(), render_server::Status::IN_PROGRESS);
@@ -30,7 +29,14 @@ Status RenderServer::RenderJob(ServerContext *context, const RenderJobRequest *r
     generateScene(job->getWidth(), job->getHeight(), job->getSamples(),
         job->getGLTF(), job->getOutput(), job->getTime());
 
-    this->manager.putObject("cube.bin", "cube.bin3", false);
+    std::stringstream stream;
+    std::string string_time;
+    stream << job->getTime();
+    stream >> string_time;
+    std::string job_name = job->getOutput() + "_" + string_time;
+    std::cout << job_name << std::endl;
+
+    this->manager.putObject(job->getOutput(), job_name, false);
     this->jobs.UpdateJobStatus(job_id, render_server::Status::COMPLETED);
     this->client.JobCompleted(job_id);
     return Status::OK;

--- a/render_worker/src/render_server.cpp
+++ b/render_worker/src/render_server.cpp
@@ -8,6 +8,12 @@
 #include <memory>
 #include <string>
 
+S3Config config {
+    .bucketName = "pathological-capstone-s3-bucket",
+    .region = "us-east-2",  // can't use other servers in same region. region must match.
+    .profileName = "default",
+};
+
 Status RenderServer::RenderJob(ServerContext *context, const RenderJobRequest *request,
     RenderJobResponse *response) {
     std::cout << "Render Recieved" << std::endl;
@@ -24,6 +30,7 @@ Status RenderServer::RenderJob(ServerContext *context, const RenderJobRequest *r
     generateScene(job->getWidth(), job->getHeight(), job->getSamples(),
         job->getGLTF(), job->getOutput(), job->getTime());
 
+    this->manager.putObject("cube.bin", "cube.bin3", false);
     this->jobs.UpdateJobStatus(job_id, render_server::Status::COMPLETED);
     this->client.JobCompleted(job_id);
     return Status::OK;
@@ -35,8 +42,7 @@ Status RenderServer::RenderStatus(ServerContext *context, const RenderStatusRequ
     return Status::OK;
 }
 
-std::unique_ptr<Server> BuildServer(uint16_t port, SchedulerClient& client,
-    std::string worker_id, random_generator rand, S3Manager& manager) {
+std::unique_ptr<Server> BuildServer(uint16_t port, SchedulerClient& client, std::string worker_id, random_generator rand) {
   std::string server_address = absl::StrFormat("0.0.0.0:%d", port);
 
   grpc::EnableDefaultHealthCheckService(true);
@@ -47,7 +53,7 @@ std::unique_ptr<Server> BuildServer(uint16_t port, SchedulerClient& client,
 
   // Register "service" as the instance through which we'll communicate with
   // clients.
-  builder.RegisterService(new RenderServer(client, worker_id, rand, manager));
+  builder.RegisterService(new RenderServer(client, worker_id, rand));
 
   // Finally assemble the server.
   std::unique_ptr<Server> server(builder.BuildAndStart());

--- a/render_worker/src/render_server.cpp
+++ b/render_worker/src/render_server.cpp
@@ -8,6 +8,7 @@
 #include <memory>
 #include <string>
 #include <sstream>
+#include <filesystem>
 
 S3Config config {
     .bucketName = "pathological-capstone-s3-bucket",
@@ -37,6 +38,12 @@ Status RenderServer::RenderJob(ServerContext *context, const RenderJobRequest *r
     std::cout << job_name << std::endl;
 
     this->manager.putObject(job->getOutput(), job_name, false);
+    if(std::filesystem::remove(job->getOutput())){
+        std::cout << "Removed: " << job->getOutput() << " locally." << std::endl;
+    }else{
+        std::cout << "Could not find render to delete" << std::endl;
+    }
+
     this->jobs.UpdateJobStatus(job_id, render_server::Status::COMPLETED);
     this->client.JobCompleted(job_id);
     return Status::OK;

--- a/render_worker/src/render_server.hpp
+++ b/render_worker/src/render_server.hpp
@@ -24,10 +24,12 @@ using boost::uuids::random_generator;
 using boost::uuids::uuid;
 using boost::uuids::to_string;
 
+extern S3Config config;
+
 class RenderServer final : public RenderWorker::Service {
 public:
-    RenderServer(SchedulerClient& client, std::string worker_id, random_generator random_gen, S3Manager& manager) :
-        client(client), worker_id(worker_id), random_gen(random_gen), manager(manager){}
+    RenderServer(SchedulerClient& client, std::string worker_id, random_generator random_gen) :
+        client(client), worker_id(worker_id), random_gen(random_gen), manager(S3Manager(config)){}
     Status RenderJob(ServerContext *context, const RenderJobRequest *request,
         RenderJobResponse *response);
     Status RenderStatus(ServerContext *context, const RenderStatusRequest *request, RenderStatusResponse *response);
@@ -37,8 +39,8 @@ private:
     std::string worker_id;
     random_generator random_gen;
     RenderJobs jobs;
-    S3Manager& manager;
+    S3Manager manager;
 };
 
 std::unique_ptr<Server> BuildServer(uint16_t port, SchedulerClient& client,
-        std::string worker_id, random_generator random_gen, S3Manager& manager);
+        std::string worker_id, random_generator random_gen);

--- a/render_worker/src/render_server.hpp
+++ b/render_worker/src/render_server.hpp
@@ -7,6 +7,7 @@
 #include <boost/uuid.hpp>
 #include "../build/protos/render_server.grpc.pb.h"
 #include "../build/protos/render_server.pb.h"
+#include "s3_manager.hpp"
 #include "scheduler_client.hpp"
 #include "render_jobs.hpp"
 
@@ -25,8 +26,8 @@ using boost::uuids::to_string;
 
 class RenderServer final : public RenderWorker::Service {
 public:
-    RenderServer(SchedulerClient& client, std::string worker_id, random_generator random_gen) :
-        client(client), worker_id(worker_id), random_gen(random_gen){}
+    RenderServer(SchedulerClient& client, std::string worker_id, random_generator random_gen, S3Manager& manager) :
+        client(client), worker_id(worker_id), random_gen(random_gen), manager(manager){}
     Status RenderJob(ServerContext *context, const RenderJobRequest *request,
         RenderJobResponse *response);
     Status RenderStatus(ServerContext *context, const RenderStatusRequest *request, RenderStatusResponse *response);
@@ -36,6 +37,8 @@ private:
     std::string worker_id;
     random_generator random_gen;
     RenderJobs jobs;
+    S3Manager& manager;
 };
 
-std::unique_ptr<Server> BuildServer(uint16_t port, SchedulerClient& client, std::string worker_id, random_generator random_gen);
+std::unique_ptr<Server> BuildServer(uint16_t port, SchedulerClient& client,
+        std::string worker_id, random_generator random_gen, S3Manager& manager);


### PR DESCRIPTION
This PR aims to upload the png rendered by the render worker to the s3 bucket instead of just keeping it locally. This is achieved by:
- Creating a config used to initialize the S3Manager
- Creating a variable to store an instance of the S3Manger within the render worker server
- Generating a job name so that they can be later assembled based on the time that they were generated at
- Uploading of the rendered png by calling the putObject method of the S3Manager instance
- PNG rendered is now deleted locally after uploading to s3 bucket