### PR TITLE
S3 frontend integration

### DIFF
--- a/frontend/app/api/render-image/route.ts
+++ b/frontend/app/api/render-image/route.ts
@@ -1,67 +1,66 @@
-// This API route fetches rendered images from the render worker's build directory, for now until s3 is implemented
 import { NextRequest, NextResponse } from 'next/server'
-import { access, readFile, unlink } from 'node:fs/promises'
 import path from 'node:path'
-//Get the content type based on the file extension, currently only supports PNG images; could be expanded in the future if we want to support video creation
+const S3_PUBLIC_BASE_URL = 'https://pathological-capstone-s3-bucket.s3.us-east-2.amazonaws.com'
+//Helper function to encode S3 object keys while preserving slashes
+function encodeS3Key(key: string) {
+  return key
+    .split('/')
+    .map((segment) => encodeURIComponent(segment))
+    .join('/')
+}
+//Take an image name/path and convert it to a full S3 URL for fetching
+function toS3ObjectUrl(image: string) {
+  const raw = image.trim()
+  if (raw.startsWith('http://') || raw.startsWith('https://')) {
+    return raw
+  }
+
+  const baseUrl = S3_PUBLIC_BASE_URL.replace(/\/+$/, '')
+  const key = raw.replace(/^\/+/, '')
+  return `${baseUrl}/${encodeS3Key(key)}`
+}
+//Helper function to determine content type based on file extension, defaulting to binary if unknown
 function getContentType(fileName: string) {
   const ext = path.extname(fileName).toLowerCase()
   if (ext === '.png') return 'image/png'
   return 'application/octet-stream'
 }
-//GET request to fetch a rendered image file from the render worker's build directory based on the image name provided in the query parameters. If the 'exists' query parameter is set to '1', it will only check if the file exists and return a JSON response indicating whether it exists or not, without returning the file content. If the file does not exist, it returns a 404 error response.
+//GET request to fetch a rendered image from S3, with optional download behavior based on query parameters
 export async function GET(req: NextRequest) {
   const url = new URL(req.url)
+  const download = url.searchParams.get('download')
   const image = url.searchParams.get('image')
-  const existsOnly = url.searchParams.get('exists') === '1'
-    // Validate that the image name is not empty or just whitespace
+
   if (!image?.trim()) {
     return NextResponse.json({ error: 'Missing image name.' }, { status: 400 })
   }
-  //Build the file path to the rendered image in the render worker's build directory
-  const fileName = path.basename(image)
-  const rootDir = path.resolve(process.cwd(), '..')
-  const filePath = path.join(rootDir, 'render_worker', 'build', fileName)
-  //Try to access the file if existsOnly is true, else just read the file and return its content with the matching application content type
-  try {
-    if (existsOnly) {
-      await access(filePath)
-      return NextResponse.json({ exists: true, file: fileName }, { status: 200 })
-    }
-    
-    const file = await readFile(filePath)
 
-    return new NextResponse(file, {
+  const fileName = path.basename(image)
+  const remoteUrl = toS3ObjectUrl(image)
+
+  try {
+    const remoteRes = await fetch(remoteUrl, {
+      method: 'GET',
+      cache: 'no-store',
+    })
+
+    if (!remoteRes.ok || !remoteRes.body) {
+      return NextResponse.json({ error: 'Rendered image not found.' }, { status: 404 })
+    }
+
+    const fileNameForDownload = path.basename(download?.trim() || fileName)
+    const contentType = remoteRes.headers.get('content-type') || getContentType(fileNameForDownload)
+    const dispositionType = download?.trim() ? 'attachment' : 'inline'
+
+    return new NextResponse(remoteRes.body, {
       status: 200,
       headers: {
-        'Content-Type': getContentType(fileName),
+        'Content-Type': contentType,
+        'Content-Disposition': `${dispositionType}; filename="${fileNameForDownload}"`,
         'Cache-Control': 'no-store',
       },
     })
   } catch {
-    if (existsOnly) {
-      return NextResponse.json({ exists: false, file: fileName }, { status: 404 })
-    }
-
     return NextResponse.json({ error: 'Rendered image not found.' }, { status: 404 })
-  }
-}
-//DELETE request to delete a rendered image file from the render worker's build directory based on the image name provided in the query parameters. It returns a JSON response indicating whether the deletion was successful or if the file was not found.
-export async function DELETE(req: NextRequest) {
-  const url = new URL(req.url)
-  const image = url.searchParams.get('image')
-
-  if (!image?.trim()) {
-    return NextResponse.json({ error: 'Missing image name.' }, { status: 400 })
-  }
-
-  const fileName = path.basename(image)
-  const rootDir = path.resolve(process.cwd(), '..')
-  const filePath = path.join(rootDir, 'render_worker', 'build', fileName)
-
-  try {
-    await unlink(filePath)
-    return NextResponse.json({ deleted: true, file: fileName }, { status: 200 })
-  } catch {
-    return NextResponse.json({ deleted: false, error: 'Rendered image not found.' }, { status: 404 })
   }
 }

--- a/frontend/app/api/renders/[id]/route.ts
+++ b/frontend/app/api/renders/[id]/route.ts
@@ -1,44 +1,27 @@
-// Next.js API route for fetching the status of a specific render job from the scheduler
 import { NextRequest, NextResponse } from 'next/server'
-// Set scheduler URL
+//Set scheduler URL
 const SCHEDULER_URL = 'http://localhost:8080'
-// Define the type for route context which includes params with an id
+//Define the expected structure of route parameters, basically
 type RouteContext = {
   params: { id: string } | Promise<{ id: string }>
 }
-//GET request to fetch the status of a specific render job from the scheduler using the render job id from the route parameters
+//GET request to fetch the status of a render job from the scheduler
 export async function GET(_: NextRequest, { params }: RouteContext) {
-  // Resolve the params to get the render job id  
   const resolvedParams = await params
-  //Get the id from the params, defaults to empty string if no id
   const id = resolvedParams?.id ?? ''
-  // Validate that the id is not empty or just whitespace
+
   if (!id.trim()) {
     return NextResponse.json({ error: 'Missing render id.' }, { status: 400 })
   }
-  // Make a GET request to the scheduler's /renders/{id}/status endpoint to fetch the status of the render job
+
   try {
     const res = await fetch(`${SCHEDULER_URL}/renders/${encodeURIComponent(id)}/status`, {
       method: 'GET',
       cache: 'no-store',
     })
-    // Check the content type of the response to determine how to parse it
-    const contentType = res.headers.get('content-type') ?? ''
-    // If the response is JSON, parse it and return it as JSON response
-    if (contentType.includes('application/json')) {
-      const data = await res.json()
-      return NextResponse.json(data, { status: res.status })
-    }
-    // If the response is not JSON, read it as text and return an error response 
-    const text = await res.text()
-    return NextResponse.json(
-      {
-        error: 'Scheduler returned a non-JSON response.',
-        status: res.status,
-        body: text,
-      },
-      { status: res.status }
-    )
+
+    const data = await res.json()
+    return NextResponse.json(data, { status: res.status })
   } catch (error) {
     return NextResponse.json(
       {

--- a/frontend/app/api/renders/route.ts
+++ b/frontend/app/api/renders/route.ts
@@ -1,20 +1,18 @@
-//Next.js API route for submitting a render job to the scheduler
 import { NextRequest, NextResponse } from 'next/server'
-import type { SubmitRenderPayload, RenderJob } from '@/types/scheduler'
+import type { SubmitRenderPayload } from '@/types/scheduler'
 //Set scheduler URL
 const SCHEDULER_URL = 'http://localhost:8080'
 //POST request to submit a render job to the scheduler
 export async function POST(req: NextRequest) {
-  //Parse the request body as JSON and type it as SubmitRenderPayload
   const body = (await req.json()) as SubmitRenderPayload
-  //Store HTTP response from the scheduler after making a POST request to the /renders endpoint with the render job details in the request body
+
   const schedulerRes = await fetch(`${SCHEDULER_URL}/renders`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(body),
     cache: 'no-store',
   })
-  //Parse the response from scheduler as JSON and cast type as RenderJob
-  const data = (await schedulerRes.json()) as RenderJob
+  //Return the scheduler's response directly to the client
+  const data = await schedulerRes.json()
   return NextResponse.json(data, { status: schedulerRes.status })
 }

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -1,13 +1,11 @@
 'use client'
 //Main and only page for the frontend, contains the form to submit render jobs to the scheduler and a section to display rendered images with options to download or delete them. It also implements polling to update the status of submitted jobs and their rendered images.
 import { useEffect, useRef, useState } from 'react'
-import type { SubmitRenderRequest, SubmitRenderPayload, RenderJob } from '@/types/scheduler'
+import Image from 'next/image'
+import type { SubmitRenderPayload, RenderJob } from '@/types/scheduler'
 // Creates type for form state based on the SubmitRenderRequest type, and a JobView type that extends RenderJob with additional fields for the requested file name and the local image URL. Also defines a SelectedImage type for managing the currently selected image in the UI.
-type FormState = SubmitRenderRequest
-type JobView = RenderJob & {
-  requestedFileName: string
-  imageUrl: string | null
-}
+type FormState = SubmitRenderPayload
+type JobView = RenderJob & { imageUrl: string | null }
 type SelectedImage = {
   src: string
   name: string
@@ -15,28 +13,62 @@ type SelectedImage = {
 //Constants for polling interval
 const POLL_INTERVAL_SECONDS = 10
 const POLL_INTERVAL_MS = POLL_INTERVAL_SECONDS * 1000
-// Helper function to build a local image URL for fetching the rendered image from the render worker's build directory based on the output filename.
-function buildLocalImageUrl(outputFilename: string) {
+const DEFAULT_FPS = 30
+const DEFAULT_RUNTIME = 10
+// Helper function to build an API image URL from an object key.
+function buildImageApiUrl(outputFilename: string) {
   return `/api/render-image?image=${encodeURIComponent(outputFilename)}&ts=${Date.now()}`
 }
-//Helper function to resolve the local image URL for a rendered image by checking if the requested file name or the output filename exists in the render worker's build directory. It makes GET requests to the /api/render-image endpoint with the 'exists' query parameter set to '1' to check for the existence.
-async function resolveLocalImageUrl(requestedFileName: string, outputFilename: string) {
-  const candidates = [requestedFileName, outputFilename].filter(
-    (name, index, arr) => name && arr.indexOf(name) === index
-  )
-
-  for (const fileName of candidates) {
-    const res = await fetch(`/api/render-image?image=${encodeURIComponent(fileName)}&exists=1`, {
-      method: 'GET',
-      cache: 'no-store',
-    })
-
-    if (res.ok) {
-      return buildLocalImageUrl(fileName)
-    }
+//Helper function to resolve an image URL by checking object-key candidates through the /api/render-image endpoint.
+function resolveApiImageUrl(
+  outputFilename: string,
+  downloadLink: string | null,
+  animationRuntime: number
+) {
+  if (downloadLink) {
+    const key = normalizeDownloadKey(downloadLink)
+    if (key) return key
   }
 
-  return null
+  const base = toFileName(outputFilename).trim()
+  if (!base) return null
+  return `${base}_${Math.trunc(animationRuntime)}`
+}
+//Function to extract the file name from a path, used to help generate output file names and resolve image URLs.
+function toFileName(value: string) {
+  return value.split('/').pop() ?? value
+}
+//Ensure file ends in .png, return a default name if result is empty after trimming
+function ensurePngName(name: string) {
+  const trimmed = toFileName(name).trim()
+  if (!trimmed) return 'render.png'
+  return /\.png$/i.test(trimmed) ? trimmed : `${trimmed}.png`
+}
+//Normarilize download link by handling both s3:// and object key
+function normalizeDownloadKey(downloadLink: string) {
+  const raw = downloadLink.trim()
+
+  if (raw.startsWith('s3://')) {
+    const withoutScheme = raw.slice('s3://'.length)
+    const slashIndex = withoutScheme.indexOf('/')
+    if (slashIndex < 0) return null
+    return withoutScheme.slice(slashIndex + 1)
+  }
+
+  if (raw.startsWith('http://') || raw.startsWith('https://')) {
+    return raw
+  }
+
+  return raw
+}
+//Resolve the image URL for a render job by checking the download link and output filename, returning a local API URL if possible
+function resolveImageUrl(
+  outputFilename: string,
+  downloadLink: string | null,
+  animationRuntime: number
+) {
+  const key = resolveApiImageUrl(outputFilename, downloadLink, animationRuntime)
+  return key ? buildImageApiUrl(key) : null
 }
 // The main React component for the home page, holds most UI state and logic 
 export default function Home() {
@@ -45,11 +77,11 @@ export default function Home() {
     {
       width: 1920,
       height: 1080,
-      frames_per_second: 30,
-      animation_runtime: 10,
+      frames_per_second: DEFAULT_FPS,
+      animation_runtime: DEFAULT_RUNTIME,
       samples_per_pixel: 16,
       scene_file_url: '/home/dtre/Pathological-V2/render_worker/test_scenes/cornell_box.gltf',
-      output_file_name: 'cornell_box.png',
+      output_filename: 'cornell_box.png',
     },
   ])
   //States for managing submission status, list of render jobs, countdown for next poll, and currently selected image for viewing
@@ -59,7 +91,6 @@ export default function Home() {
   const [selectedImage, setSelectedImage] = useState<SelectedImage | null>(null)
 
   const jobsRef = useRef<JobView[]>([])
-  const pollingStartedRef = useRef(false)
 
   useEffect(() => {
     jobsRef.current = jobs
@@ -76,7 +107,7 @@ export default function Home() {
       next[index] = {
         ...next[index],
         scene_file_url: v,
-        output_file_name: filename,
+        output_filename: filename,
       }
       return next
     })
@@ -104,49 +135,56 @@ export default function Home() {
       {
         width: 1920,
         height: 1080,
-        frames_per_second: 30,
-        animation_runtime: 10,
+        frames_per_second: DEFAULT_FPS,
+        animation_runtime: DEFAULT_RUNTIME,
         samples_per_pixel: 16,
         scene_file_url: '',
-        output_file_name: '',
+        output_filename: '',
       },
     ])
   }
 
-  function onDownload(outputFilename: string) {
-    const href = `/api/render-image?image=${encodeURIComponent(outputFilename)}`
+  function onRemove(index: number) {
+    setForms((prev) => prev.filter((_, i) => i !== index))
+  }
+
+  async function onDownload(job: JobView) {
+    const key = resolveApiImageUrl(job.output_filename, job.download_link, job.animation_runtime)
+    if (!key) return
+
+    const downloadName = ensurePngName(job.output_filename)
+
+    const localDownloadUrl = `/api/render-image?image=${encodeURIComponent(key)}&download=${encodeURIComponent(downloadName)}`
     const anchor = document.createElement('a')
-    anchor.href = href
-    anchor.download = outputFilename
+    anchor.href = localDownloadUrl
+    anchor.download = downloadName
     document.body.appendChild(anchor)
     anchor.click()
     anchor.remove()
   }
+//Handler for when a user clicks on a rendered image to view it, sets the selected image state to open the image viewer modal
+  async function onOpenImage(job: JobView) {
+    const src = resolveImageUrl(job.output_filename, job.download_link, job.animation_runtime)
 
-  async function onDelete(index: number, outputFilename: string) {
-    const res = await fetch(`/api/render-image?image=${encodeURIComponent(outputFilename)}`, {
-      method: 'DELETE',
-    })
+    if (!src) return
+    setSelectedImage({ src, name: job.output_filename })
+  }
 
-    if (!res.ok) {
-      return
-    }
-
+  function onDelete(index: number, outputFilename: string) {
     setJobs((prev) => prev.filter((_, i) => i !== index))
     setSelectedImage((prev) => (prev?.name === outputFilename ? null : prev))
   }
-
+//Handler for submitting the render job form; sends a POST request to the /api/renders endpoint for each form, then updates the jobs state with the responses and starts the polling countdown
   async function onSubmit() {
     try {
       setSubmitting(true)
 
       const results = await Promise.all(
         forms.map(async (form) => {
-          const { output_file_name, ...rest } = form
-
           const payload: SubmitRenderPayload = {
-            ...rest,
-            output_filename: output_file_name,
+            ...form,
+            frames_per_second: DEFAULT_FPS,
+            animation_runtime: DEFAULT_RUNTIME,
           }
 
           const res = await fetch('/api/renders', {
@@ -160,11 +198,10 @@ export default function Home() {
           }
 
           const data = (await res.json()) as RenderJob
-          const imageUrl = await resolveLocalImageUrl(form.output_file_name, data.output_filename)
+          const imageUrl = resolveImageUrl(data.output_filename, data.download_link, data.animation_runtime)
 
           return {
             ...data,
-            requestedFileName: form.output_file_name,
             imageUrl,
           } as JobView
         })
@@ -172,117 +209,110 @@ export default function Home() {
 
       setJobs(results)
       setSecondsUntilNextPoll(POLL_INTERVAL_SECONDS)
-      pollingStartedRef.current = false
     } catch (error) {
       console.error(error)
     } finally {
       setSubmitting(false)
     }
   }
-
+//useEffect hook to implement polling for job status updates and image URL resolution, with a countdown timer for the next poll
   useEffect(() => {
     if (jobs.length === 0) {
       setSecondsUntilNextPoll(POLL_INTERVAL_SECONDS)
-      pollingStartedRef.current = false
       return
     }
 
-    if (pollingStartedRef.current) return
-    pollingStartedRef.current = true
-
     let isCancelled = false
-    let countdownInterval: ReturnType<typeof setInterval> | null = null
-    let pollTimeout: ReturnType<typeof setTimeout> | null = null
+    let remaining = POLL_INTERVAL_SECONDS
 
-    const clearTimers = () => {
-      if (countdownInterval) clearInterval(countdownInterval)
-      if (pollTimeout) clearTimeout(pollTimeout)
-    }
+    setSecondsUntilNextPoll(remaining)
 
-    const runPollCycle = () => {
-      if (isCancelled) return
+    const countdownInterval = setInterval(() => {
+      remaining = remaining > 1 ? remaining - 1 : POLL_INTERVAL_SECONDS
+      if (!isCancelled) {
+        setSecondsUntilNextPoll(remaining)
+      }
+    }, 1000)
 
-      setSecondsUntilNextPoll(POLL_INTERVAL_SECONDS)
+    const pollInterval = setInterval(async () => {
+      try {
+        const currentJobs = jobsRef.current
+        const hasPollableJobs = currentJobs.some((job) => {
+          const id = String(job.id ?? '').trim()
+          const shouldRefreshStatus = job.status !== 'Completed' && job.status !== 'Error'
+          const shouldResolveImage = job.status !== 'Error' && job.imageUrl === null
+          return id !== '' && (shouldRefreshStatus || shouldResolveImage)
+        })
 
-      let remaining = POLL_INTERVAL_SECONDS
+        if (!hasPollableJobs) return
 
-      countdownInterval = setInterval(() => {
-        remaining -= 1
+        const updated = await Promise.all(
+          currentJobs.map(async (job) => {
+            if (job.status === 'Error') return job
 
-        if (remaining >= 0 && !isCancelled) {
-          setSecondsUntilNextPoll(remaining)
-        }
-
-        if (remaining <= 0 && countdownInterval) {
-          clearInterval(countdownInterval)
-        }
-      }, 1000)
-
-      pollTimeout = setTimeout(async () => {
-        try {
-          const currentJobs = jobsRef.current
-          const hasPollableJobs = currentJobs.some((job) => {
             const id = String(job.id ?? '').trim()
-            const isTerminal = job.status === 'Completed' || job.status === 'Error'
-            const isLocalComplete = job.status !== 'Error' && job.imageUrl !== null
-            return id !== '' && !isTerminal && !isLocalComplete
-          })
+            if (!id) return job
 
-          if (hasPollableJobs) {
-            const updated = await Promise.all(
-              currentJobs.map(async (job) => {
-                const isTerminal = job.status === 'Completed' || job.status === 'Error'
-                const isLocalComplete = job.status !== 'Error' && job.imageUrl !== null
-                if (isTerminal || isLocalComplete) return job
+            const currentImageUrl = resolveImageUrl(job.output_filename, job.download_link, job.animation_runtime)
 
-                const res = await fetch(`/api/renders/${encodeURIComponent(String(job.id))}`, {
-                  method: 'GET',
-                  cache: 'no-store',
-                })
-
-                if (!res.ok) {
-                  throw new Error(`Polling failed for id=${String(job.id)} with status ${res.status}`)
-                }
-
-                const data = (await res.json()) as RenderJob
-                const imageUrl = job.imageUrl ?? (await resolveLocalImageUrl(job.requestedFileName, data.output_filename))
-
-                return {
-                  ...data,
-                  requestedFileName: job.requestedFileName,
-                  imageUrl,
-                } as JobView
-              })
-            )
-
-            if (!isCancelled) {
-              setJobs(updated)
+            if (job.status === 'Completed') {
+              return {
+                ...job,
+                imageUrl: currentImageUrl,
+              } as JobView
             }
-          }
-        } catch (error) {
-          console.error(error)
-        } finally {
-          if (!isCancelled) {
-            runPollCycle()
-          }
-        }
-      }, POLL_INTERVAL_MS)
-    }
 
-    runPollCycle()
+            try {
+              const res = await fetch(`/api/renders/${encodeURIComponent(String(job.id))}`, {
+                method: 'GET',
+                cache: 'no-store',
+              })
+
+              if (!res.ok) {
+                return {
+                  ...job,
+                  imageUrl: currentImageUrl,
+                } as JobView
+              }
+
+              const data = (await res.json()) as RenderJob
+              const imageUrl = resolveImageUrl(data.output_filename, data.download_link, data.animation_runtime)
+
+              return {
+                ...data,
+                imageUrl,
+              } as JobView
+            } catch {
+              return {
+                ...job,
+                imageUrl: currentImageUrl,
+              } as JobView
+            }
+          })
+        )
+
+        if (!isCancelled) {
+          setJobs(updated)
+        }
+      } catch (error) {
+        console.error(error)
+      }
+    }, POLL_INTERVAL_MS)
 
     return () => {
       isCancelled = true
-      pollingStartedRef.current = false
-      clearTimers()
+      clearInterval(countdownInterval)
+      clearInterval(pollInterval)
     }
   }, [jobs.length])
 
   const activeJobCount = jobs.filter((job) => {
-    const isTerminal = job.status === 'Completed' || job.status === 'Error'
-    const isLocalComplete = job.status !== 'Error' && job.imageUrl !== null
-    return !isTerminal && !isLocalComplete
+    if (job.status === 'Error') return false
+    if (job.status === 'Completed' && job.imageUrl !== null) return false
+    return true
   }).length
+
+  
 //UI rendering logic
   return (
     <div className="flex min-h-screen flex-col bg-black text-red-500 font-mono">
@@ -332,7 +362,18 @@ export default function Home() {
 
             <div className="space-y-5">
               {forms.map((form, i) => (
-                <div key={i} className="space-y-5 rounded-lg border border-red-900/60 bg-black/20 p-4">
+                <div key={i} className="relative space-y-5 rounded-lg border border-red-900/60 bg-black/20 p-4">
+                  {i > 0 ? (
+                    <button
+                      type="button"
+                      onClick={() => onRemove(i)}
+                      aria-label={`Remove render form ${i + 1}`}
+                      className="absolute right-2 top-2 rounded border border-red-700 px-2 py-0.5 text-xs font-bold text-red-300 transition-all hover:text-red-100 hover:drop-shadow-[0_0_8px_rgba(220,38,38,0.9)]"
+                    >
+                      X
+                    </button>
+                  ) : null}
+
                   <div className="space-y-2">
                     <label className="block text-sm font-semibold text-red-300">Scene file (.gltf)</label>
                     <input
@@ -347,30 +388,8 @@ export default function Home() {
                     <div className="space-y-2">
                       <label className="block text-sm font-semibold text-red-300">Output filename</label>
                       <input
-                        value={form.output_file_name}
-                        onChange={(e) => onTextChange(i, 'output_file_name', e.target.value)}
-                        className="w-full rounded-lg border border-red-800 bg-black px-3 py-2 text-red-200 placeholder:text-red-700 focus:outline-none focus:ring-2 focus:ring-red-700"
-                      />
-                    </div>
-
-                    <div className="space-y-2">
-                      <label className="block text-sm font-semibold text-red-300">Frames / Second</label>
-                      <input
-                        type="number"
-                        min={1}
-                        value={form.frames_per_second}
-                        onChange={(e) => onNumberChange(i, 'frames_per_second', e.target.value)}
-                        className="w-full rounded-lg border border-red-800 bg-black px-3 py-2 text-red-200 placeholder:text-red-700 focus:outline-none focus:ring-2 focus:ring-red-700"
-                      />
-                    </div>
-
-                    <div className="space-y-2">
-                      <label className="block text-sm font-semibold text-red-300">Animation runtime</label>
-                      <input
-                        type="number"
-                        min={1}
-                        value={form.animation_runtime}
-                        onChange={(e) => onNumberChange(i, 'animation_runtime', e.target.value)}
+                        value={form.output_filename}
+                        onChange={(e) => onTextChange(i, 'output_filename', e.target.value)}
                         className="w-full rounded-lg border border-red-800 bg-black px-3 py-2 text-red-200 placeholder:text-red-700 focus:outline-none focus:ring-2 focus:ring-red-700"
                       />
                     </div>
@@ -472,7 +491,7 @@ export default function Home() {
                       <div className="grid grid-cols-3 items-center gap-2">
                         <button
                           type="button"
-                          onClick={() => onDownload(job.output_filename)}
+                          onClick={() => onDownload(job)}
                           disabled={!job.imageUrl}
                           className={`justify-self-start rounded border border-red-800 px-2 py-1 text-xs font-semibold transition-all ${
                             job.imageUrl
@@ -496,13 +515,16 @@ export default function Home() {
                       {job.imageUrl ? (
                         <button
                           type="button"
-                          onClick={() => setSelectedImage({ src: job.imageUrl as string, name: job.output_filename })}
+                          onClick={() => onOpenImage(job)}
                           className="mt-3 block w-full"
                         >
                           <div className="flex h-56 w-full items-center justify-center overflow-hidden rounded-md border border-red-900/60 bg-black/40">
-                            <img
+                            <Image
                               src={job.imageUrl}
-                              alt={job.requestedFileName}
+                              alt={job.output_filename}
+                              width={1024}
+                              height={1024}
+                              unoptimized
                               className="h-full w-full object-contain"
                             />
                           </div>
@@ -529,9 +551,12 @@ export default function Home() {
         >
           <div className="w-full max-w-5xl rounded-lg border border-red-800 bg-black p-4">
             <div className="mb-3 text-center text-sm font-semibold text-red-300">{selectedImage.name}</div>
-            <img
+            <Image
               src={selectedImage.src}
               alt={selectedImage.name}
+              width={1920}
+              height={1080}
+              unoptimized
               className="max-h-[80vh] w-full rounded-md border border-red-900/60 object-contain"
             />
           </div>

--- a/frontend/types/scheduler.ts
+++ b/frontend/types/scheduler.ts
@@ -1,13 +1,3 @@
-export type SubmitRenderRequest = {
-  width: number
-  height: number
-  frames_per_second: number
-  animation_runtime: number
-  samples_per_pixel: number
-  scene_file_url: string
-  output_file_name: string
-}
-
 export type SubmitRenderPayload = {
   width: number
   height: number
@@ -17,6 +7,8 @@ export type SubmitRenderPayload = {
   scene_file_url: string
   output_filename: string
 }
+
+export type SubmitRenderRequest = SubmitRenderPayload
 
 export type RenderStatus = 'Completed' | 'In Progress' | 'In Queue' | 'Error'
 

--- a/scheduler/src/scheduler.cpp
+++ b/scheduler/src/scheduler.cpp
@@ -1,4 +1,29 @@
 #include "scheduler.hpp"
+#include "render_history.hpp"
+#include "renderStatus.hpp"
+#include "s3Manager.hpp"
+#include <boost/uuid/string_generator.hpp>
+#include <boost/uuid/uuid_io.hpp>
+
+namespace {
+constexpr const char* kBucketName = "pathological-capstone-s3-bucket";
+constexpr const char* kBucketRegion = "us-east-2";
+
+std::optional<std::string> buildDownloadLink(const std::string& key) {
+    static S3Manager s3Manager({
+        .bucketName = kBucketName,
+        .region = kBucketRegion,
+        .profileName = "default",
+    });
+
+    const auto presigned = s3Manager.requestFileUrl(key);
+    if (presigned && !presigned->empty()) {
+        return presigned;
+    }
+
+    return std::string("s3://") + kBucketName + "/" + key;
+}
+}
 
 void Scheduler::addJob(std::shared_ptr<RenderRequest> job) {
     {
@@ -54,6 +79,30 @@ void Scheduler::markWorkerIdle(const std::string& id) {
         }
     }
     job_available_.notify_one();
+}
+
+bool Scheduler::markRenderCompleted(const std::string& workerJobId) {
+    std::string renderId;
+    {
+        std::lock_guard<std::mutex> lock(job_map_mutex_);
+        auto it = worker_job_to_render_id_.find(workerJobId);
+        if (it == worker_job_to_render_id_.end()) {
+            return false;
+        }
+        renderId = it->second;
+        worker_job_to_render_id_.erase(it);
+    }
+
+    boost::uuids::string_generator stringGen;
+    const boost::uuids::uuid uuid = stringGen(renderId);
+    auto render = RenderHistory::getInstance().getRenderRequest(uuid);
+    if (!render) {
+        return false;
+    }
+    const std::string key = render->getOutputFileName() + "_" + std::to_string(render->getAnimationRuntimeInFrames());
+    render->setDownloadLink(buildDownloadLink(key));
+    render->setStatus(RenderStatus::COMPLETED);
+    return true;
 }
 
 void Scheduler::run() {
@@ -117,11 +166,13 @@ void Scheduler::assignJobs() {
 
         std::string worker_id = worker->id;
         std::string worker_address = worker->ip + ":" + std::to_string(worker->port);
+        std::string render_id = boost::uuids::to_string(job->getId());
         worker->status = WorkerStatus::BUSY;
+        RenderHistory::getInstance().updateStatus(job->getId(), RenderStatus::IN_PROGRESS);
 
         // Spin up a thread per dispatch so gRPC calls don't block the loop
         std::lock_guard<std::mutex> tlock(threads_mutex_);
-        dispatch_threads_.emplace_back([this, worker_id, worker_address, job]() {
+        dispatch_threads_.emplace_back([this, worker_id, worker_address, job, render_id]() {
             std::cout << "Dispatching to: " << worker_address << std::endl;
             RenderWorkerClient client(
                 grpc::CreateChannel(worker_address, grpc::InsecureChannelCredentials())
@@ -129,6 +180,7 @@ void Scheduler::assignJobs() {
  
             std::string job_id = client.RenderJob(job);
             if (job_id == "ERROR") {
+                RenderHistory::getInstance().updateStatus(job->getId(), RenderStatus::ERROR);
                 {
                     std::lock_guard<std::mutex> qlock(queue_mutex_);
                     pending_jobs_.push(job);
@@ -138,6 +190,14 @@ void Scheduler::assignJobs() {
                     Worker* w = findWorkerByID(worker_id);
                     if (w) w->status = WorkerStatus::OFFLINE;
                 }
+            } else {
+                {
+                    std::lock_guard<std::mutex> mapLock(job_map_mutex_);
+                    worker_job_to_render_id_[job_id] = render_id;
+                }
+
+                // Handle out-of-order completion notifications by finalizing here too.
+                markRenderCompleted(job_id);
             }
         });
     }

--- a/scheduler/src/scheduler.hpp
+++ b/scheduler/src/scheduler.hpp
@@ -8,6 +8,7 @@
 #include <atomic>
 #include <string>
 #include <iostream>
+#include <unordered_map>
 
 #include <grpcpp/grpcpp.h>
 
@@ -35,6 +36,7 @@ public:
     void reconnectWorker(const std::string& id);
     void markWorkerOffline(const std::string& id);
     void markWorkerIdle(const std::string& id);
+    bool markRenderCompleted(const std::string& workerJobId);
 
     void run();
     void stop();
@@ -52,6 +54,10 @@ private:
     // Worker list
     std::vector<Worker> workers_;
     std::mutex workers_mutex_;
+
+    // Tracks worker generated job IDs to scheduler render IDs.
+    std::unordered_map<std::string, std::string> worker_job_to_render_id_;
+    std::mutex job_map_mutex_;
 
     // Dispatch thread tracking
     std::vector<std::thread> dispatch_threads_;

--- a/scheduler/src/scheduler_server.cpp
+++ b/scheduler/src/scheduler_server.cpp
@@ -41,6 +41,7 @@ Status SchedulerServer::JobCompleted(ServerContext* context, const JobCompletedR
 
     // A recognized worker will be set to idle once a job is completed.
     if (worker != nullptr) {
+        Scheduler::getInstance().markRenderCompleted(request->job_id());
         Scheduler::getInstance().markWorkerIdle(request->worker_id());
         std::cout << "Job " << request->job_id() << " completed by worker: " << request->worker_id() << std::endl;
         response->set_status(RegistrationStatus::OK);


### PR DESCRIPTION
Frontend Changes:
-Replaced old local build-file reads with S3 fetch.
-Simplified API routes
-Page.ts: refactors image display to use scheduler download_link or derived keys, simplifies polling, 

Backend:
-Scheduler.hpp: Added worker-job-to-render mapping and markRenderCompleted method so scheduler can man mark render status. 
-Scheduler.cpp: now tracks worker job IDs to scheduler render IDs, updates render status through In Progress and Error states, and sets download_link on completion; also adds presigned URL generation
-Scheduler_server.cpp: updates JobCompleted handling to finalize the render record before marking the worker idle.

