### PR TITLE
Implement real per-frame scheduling instead of one-frame-per-request

### DIFF
--- a/protos/render_server.proto
+++ b/protos/render_server.proto
@@ -21,7 +21,9 @@ message RenderJobRequest {
   uint32 width = 3;
   uint32 height = 4;
   uint32 samples = 5;
-  float time = 6;
+  float time = 6; // Animation time in seconds for this specific frame.
+  string job_id = 7; // Scheduler-assigned id, registered before dispatch so completion can't race the response.
+  uint32 frame_index = 8; // Which frame of the animation this is; used to name the uploaded output deterministically.
 }
 
 // Render worker returns a unique job identifier so that the Scheduler can refer back to the render

--- a/render_worker/src/job.cpp
+++ b/render_worker/src/job.cpp
@@ -27,6 +27,10 @@ float Job::getTime(){
     return this->time;
 }
 
+uint32_t Job::getFrameIndex(){
+    return this->frameIndex;
+}
+
 void Job::setStatus(render_server::Status status){
     this->status = status;
 }
@@ -43,5 +47,6 @@ void Job::print(){
     std::cout << gltfFile << std::endl;
     std::cout << output << std::endl;
     std::cout << time << std::endl;
+    std::cout << frameIndex << std::endl;
     std::cout << status << std::endl;
 }

--- a/render_worker/src/job.hpp
+++ b/render_worker/src/job.hpp
@@ -7,15 +7,17 @@
 class Job {
 public:
     Job(uint32_t width, uint32_t height, uint32_t samples,
-        std::string gltfFile, std::string output, float time, render_server::Status status) :
+        std::string gltfFile, std::string output, float time, uint32_t frameIndex,
+        render_server::Status status) :
         width(width), height(height), samples(samples),
-        gltfFile(gltfFile), output(output), time(time), status(status) {}
+        gltfFile(gltfFile), output(output), time(time), frameIndex(frameIndex), status(status) {}
     uint32_t getWidth();
     uint32_t getHeight();
     uint32_t getSamples();
     std::string getGLTF();
     std::string getOutput();
     float getTime();
+    uint32_t getFrameIndex();
     void setStatus(render_server::Status status);   // Only setter on Status as that is the only thing
                                                     // that needs to be changed. The rest are set
                                                     // on construction
@@ -30,5 +32,6 @@ private:
     std::string gltfFile;
     std::string output;
     float time;
+    uint32_t frameIndex;
     render_server::Status status;
 };

--- a/render_worker/src/render_server.cpp
+++ b/render_worker/src/render_server.cpp
@@ -2,12 +2,9 @@
 #include "render_worker.hpp"
 #include "s3_manager.hpp"
 #include "scheduler_client.hpp"
-#include <boost/uuid/random_generator.hpp>
-#include <boost/uuid/uuid_io.hpp>
 #include <iostream>
 #include <memory>
 #include <string>
-#include <sstream>
 #include <filesystem>
 
 // Used for s3 uploads. Will need to change bucket
@@ -25,12 +22,15 @@ Status RenderServer::RenderJob(ServerContext *context, const RenderJobRequest *r
     RenderJobResponse *response) {
     std::cout << "Render Recieved" << std::endl;
 
-    // Makes shared_ptr to job instance and creates UUID
+    // Makes shared_ptr to job instance. The job id comes from the scheduler
+    // (not generated here) so it can register the id -> render mapping
+    // before dispatching, ahead of this handler's JobCompleted callback.
     std::shared_ptr<Job> job = std::make_shared<Job>(request->width(), request->height(), request->samples(),
-        request->scene_location(), request->output_name(), request->time(), render_server::Status::IN_PROGRESS);
-    std::string job_id = boost::uuids::to_string(random_gen());
+        request->scene_location(), request->output_name(), request->time(), request->frame_index(),
+        render_server::Status::IN_PROGRESS);
+    std::string job_id = request->job_id();
 
-    // Sends UUID to scheduler for tracking and
+    // Sends id back to scheduler for confirmation and
     // adds job to instance of RenderJobs class
     response->set_job_identifier(job_id);
     this->jobs.AddJob(job_id, job);
@@ -39,13 +39,10 @@ Status RenderServer::RenderJob(ServerContext *context, const RenderJobRequest *r
     generateScene(job->getWidth(), job->getHeight(), job->getSamples(),
         job->getGLTF(), job->getOutput(), job->getTime(), 512, false);
 
-    // Generates name for s3 upload
-    // currently {output}_{time}
-    std::stringstream stream;
-    std::string string_time;
-    stream << job->getTime();
-    stream >> string_time;
-    std::string job_name = job->getOutput() + "_" + string_time;
+    // Generates name for s3 upload: {output}_{frame_index}. Keyed by frame
+    // index (not the float time) so uploads are deterministic and sort in
+    // frame order.
+    std::string job_name = job->getOutput() + "_" + std::to_string(job->getFrameIndex());
     std::cout << job_name << std::endl;
 
     // Adds render to s3 bucket and removes render from

--- a/scheduler/src/renderRequest.cpp
+++ b/scheduler/src/renderRequest.cpp
@@ -53,6 +53,10 @@ const std::optional<std::string> &RenderRequest::getDownloadLink() const {
   return this->downloadLink;
 }
 
+const std::vector<std::string> &RenderRequest::getDownloadLinks() const {
+  return this->downloadLinks;
+}
+
 RenderRequest &RenderRequest::setStatus(RenderStatus status) {
   this->status = status;
   return *this;
@@ -135,6 +139,12 @@ RenderRequest::setDownloadLink(const std::optional<std::string> &link) {
   return *this;
 }
 
+RenderRequest &
+RenderRequest::setDownloadLinks(const std::vector<std::string> &links) {
+  this->downloadLinks = links;
+  return *this;
+}
+
 Json::Value RenderRequest::toJson() const {
   Json::Value ret;
 
@@ -156,6 +166,16 @@ Json::Value RenderRequest::toJson() const {
   } else {
     ret["download_link"] = Json::nullValue;
   }
+
+  // One entry per rendered frame, in frame order. Populated once the render
+  // completes; empty (not null) while frames are still in progress.
+  Json::Value links(Json::arrayValue);
+  if (this->status == RenderStatus::COMPLETED) {
+    for (const auto &link : this->downloadLinks) {
+      links.append(link);
+    }
+  }
+  ret["download_links"] = links;
 
   return ret;
 }

--- a/scheduler/src/renderRequest.hpp
+++ b/scheduler/src/renderRequest.hpp
@@ -4,6 +4,7 @@
 #include <json/json.h>
 #include <optional>
 #include <string>
+#include <vector>
 
 #include "renderStatus.hpp"
 
@@ -31,6 +32,7 @@ public:
   const std::string &getCreatedAtTimestamp() const;
   const std::string &getOutputFileName() const;
   const std::optional<std::string> &getDownloadLink() const;
+  const std::vector<std::string> &getDownloadLinks() const;
 
   RenderRequest &setStatus(RenderStatus status);
   RenderRequest &setWidth(int w);
@@ -44,6 +46,7 @@ public:
   RenderRequest &setCreatedAtTimestamp(const std::string &time);
   RenderRequest &setOutputFileName(const std::string &name);
   RenderRequest &setDownloadLink(const std::optional<std::string> &link);
+  RenderRequest &setDownloadLinks(const std::vector<std::string> &links);
 
   Json::Value toJson() const;
 
@@ -61,4 +64,5 @@ private:
   std::string createdAt;
   std::string outputFileName;
   std::optional<std::string> downloadLink;
+  std::vector<std::string> downloadLinks;
 };

--- a/scheduler/src/render_client.cpp
+++ b/scheduler/src/render_client.cpp
@@ -2,7 +2,8 @@
 
 // Assembles the client's payload using getter functions from renderRequest.cpp, sends it and presents the response back
 // from the server.
-std::string RenderWorkerClient::RenderJob(std::shared_ptr<RenderRequest> render) {
+bool RenderWorkerClient::RenderJob(std::shared_ptr<RenderRequest> render, const std::string& job_id,
+    uint32_t frame_index, float time) {
   // Data we are sending and getting back
   RenderJobRequest request;
   RenderJobResponse response;
@@ -14,17 +15,19 @@ std::string RenderWorkerClient::RenderJob(std::shared_ptr<RenderRequest> render)
   request.set_width(static_cast<uint32_t>(render->getWidth()));
   request.set_height(static_cast<uint32_t>(render->getHeight()));
   request.set_samples(static_cast<uint32_t>(render->getSamplesPerPixel()));
-  request.set_time(static_cast<float>(render->getAnimationRuntimeInFrames())); // ****I'm ASSUMING this is what is from the frontend
+  request.set_time(time);
+  request.set_job_id(job_id);
+  request.set_frame_index(frame_index);
 
   // The actual RPC.
   Status status = stub_->RenderJob(&context, request, &response);
 
   // Act upon its status.
   if (status.ok()) {
-    return response.job_identifier();
+    return true;
   } else {
     std::cout << status.error_code() << ": " << status.error_message() << std::endl;
-    return "ERROR";
+    return false;
   }
 }
 

--- a/scheduler/src/render_client.hpp
+++ b/scheduler/src/render_client.hpp
@@ -20,7 +20,12 @@ class RenderWorkerClient {
 public:
     RenderWorkerClient(std::shared_ptr<Channel> channel) : stub_(RenderWorker::NewStub(channel)) {}
 
-    std::string RenderJob(std::shared_ptr<RenderRequest> render);
+    // Dispatches a single frame of `render`. `job_id` is scheduler-assigned
+    // (the scheduler registers it before calling this, so the worker's
+    // JobCompleted callback can never race ahead of the registration).
+    // Returns true if the worker accepted the frame.
+    bool RenderJob(std::shared_ptr<RenderRequest> render, const std::string& job_id,
+        uint32_t frame_index, float time);
     int RenderStatus(std::string job);
 
 private:

--- a/scheduler/src/scheduler.cpp
+++ b/scheduler/src/scheduler.cpp
@@ -27,12 +27,32 @@ std::optional<std::string> buildDownloadLink(const std::string& key) {
 }
 
 void Scheduler::addJob(std::shared_ptr<RenderRequest> job) {
+    const int totalFrames = job->getAnimationRuntimeInFrames();
+    const int fps = job->getFramesPerSecond();
+    if (totalFrames <= 0) {
+        std::cout << "Render request has no frames to schedule, skipping." << std::endl;
+        return;
+    }
+
+    const std::string renderId = boost::uuids::to_string(job->getId());
+    {
+        std::lock_guard<std::mutex> lock(progress_mutex_);
+        RenderProgress progress;
+        progress.totalFrames = static_cast<uint32_t>(totalFrames);
+        progress.frameLinks.resize(totalFrames);
+        render_progress_[renderId] = std::move(progress);
+    }
+
     {
         std::lock_guard<std::mutex> lock(queue_mutex_);
-        pending_jobs_.push(job);
-        std::cout << "Job added to queue. Queue size: " << pending_jobs_.size() << std::endl;
+        for (int i = 0; i < totalFrames; ++i) {
+            const float time = fps > 0 ? static_cast<float>(i) / static_cast<float>(fps) : static_cast<float>(i);
+            pending_jobs_.push(FrameJob{job, static_cast<uint32_t>(i), time});
+        }
+        std::cout << "Queued " << totalFrames << " frame(s) for render " << renderId
+                   << ". Queue size: " << pending_jobs_.size() << std::endl;
     }
-    job_available_.notify_one();
+    job_available_.notify_all();
 }
 
 void Scheduler::registerWorker(const std::string& id, const std::string& ip, uint32_t port) {
@@ -83,26 +103,68 @@ void Scheduler::markWorkerIdle(const std::string& id) {
 }
 
 bool Scheduler::markRenderCompleted(const std::string& workerJobId) {
-    std::string renderId;
+    FrameJobContext ctx;
     {
         std::lock_guard<std::mutex> lock(job_map_mutex_);
         auto it = worker_job_to_render_id_.find(workerJobId);
         if (it == worker_job_to_render_id_.end()) {
             return false;
         }
-        renderId = it->second;
+        ctx = it->second;
         worker_job_to_render_id_.erase(it);
     }
 
     boost::uuids::string_generator stringGen;
-    const boost::uuids::uuid uuid = stringGen(renderId);
+    const boost::uuids::uuid uuid = stringGen(ctx.renderId);
     auto render = RenderHistory::getInstance().getRenderRequest(uuid);
     if (!render) {
         return false;
     }
-    const std::string key = render->getOutputFileName() + "_" + std::to_string(render->getAnimationRuntimeInFrames());
-    render->setDownloadLink(buildDownloadLink(key));
-    render->setStatus(RenderStatus::COMPLETED);
+
+    // Frames are named by index, not by float-formatted time, so uploads are
+    // deterministic and the collection can be reassembled in order.
+    const std::string key = render->getOutputFileName() + "_" + std::to_string(ctx.frameIndex);
+    const auto link = buildDownloadLink(key);
+
+    bool allFramesDone = false;
+    uint32_t framesCompleted = 0;
+    uint32_t totalFrames = 0;
+    std::vector<std::string> orderedLinks;
+    {
+        std::lock_guard<std::mutex> lock(progress_mutex_);
+        auto it = render_progress_.find(ctx.renderId);
+        if (it == render_progress_.end()) {
+            // Already finalized (e.g. a duplicate completion notification).
+            return false;
+        }
+        RenderProgress& progress = it->second;
+        if (ctx.frameIndex < progress.frameLinks.size() && !progress.frameLinks[ctx.frameIndex]) {
+            progress.frameLinks[ctx.frameIndex] = link;
+            progress.framesCompleted++;
+        }
+        framesCompleted = progress.framesCompleted;
+        totalFrames = progress.totalFrames;
+        allFramesDone = framesCompleted >= totalFrames;
+        if (allFramesDone) {
+            orderedLinks.reserve(progress.frameLinks.size());
+            for (auto& frameLink : progress.frameLinks) {
+                orderedLinks.push_back(frameLink.value_or(""));
+            }
+            render_progress_.erase(it);
+        }
+    }
+
+    render->setFramesCompleted(framesCompleted);
+
+    if (allFramesDone) {
+        render->setDownloadLinks(orderedLinks);
+        if (!orderedLinks.empty()) {
+            render->setDownloadLink(orderedLinks.front());
+        }
+        render->setStatus(RenderStatus::COMPLETED);
+        std::cout << "Render " << ctx.renderId << " completed with " << totalFrames << " frame(s)." << std::endl;
+    }
+
     return true;
 }
 
@@ -162,46 +224,63 @@ void Scheduler::assignJobs() {
             std::cout << "No idle workers available, jobs in queue: " << pending_jobs_.size() << std::endl;
             break;
         }
-        std::shared_ptr<RenderRequest> job = pending_jobs_.front();
+        FrameJob frameJob = pending_jobs_.front();
         pending_jobs_.pop();
 
         std::string worker_id = worker->id;
         std::string worker_address = worker->ip + ":" + std::to_string(worker->port);
-        std::string render_id = boost::uuids::to_string(job->getId());
+        std::string render_id = boost::uuids::to_string(frameJob.renderRequest->getId());
+        std::string job_id = generateJobId();
         worker->status = WorkerStatus::BUSY;
-        RenderHistory::getInstance().updateStatus(job->getId(), RenderStatus::IN_PROGRESS);
+        RenderHistory::getInstance().updateStatus(frameJob.renderRequest->getId(), RenderStatus::IN_PROGRESS);
+
+        // Registered before dispatch (not after the RPC returns) because the
+        // worker's RenderJob handler is synchronous: it calls back with
+        // JobCompleted before its own RPC response reaches us. Registering
+        // here guarantees the mapping exists by the time that callback
+        // arrives instead of racing it.
+        {
+            std::lock_guard<std::mutex> mapLock(job_map_mutex_);
+            worker_job_to_render_id_[job_id] = FrameJobContext{render_id, frameJob.frameIndex};
+        }
 
         // Spin up a thread per dispatch so gRPC calls don't block the loop
         std::lock_guard<std::mutex> tlock(threads_mutex_);
-        dispatch_threads_.emplace_back([this, worker_id, worker_address, job, render_id]() {
-            std::cout << "Dispatching to: " << worker_address << std::endl;
+        dispatch_threads_.emplace_back([this, worker_id, worker_address, frameJob, job_id]() {
+            std::cout << "Dispatching frame " << frameJob.frameIndex << " to: " << worker_address << std::endl;
             RenderWorkerClient client(
                 grpc::CreateChannel(worker_address, grpc::InsecureChannelCredentials())
             );
- 
-            std::string job_id = client.RenderJob(job);
-            if (job_id == "ERROR") {
-                RenderHistory::getInstance().updateStatus(job->getId(), RenderStatus::ERROR);
+
+            const bool accepted = client.RenderJob(frameJob.renderRequest, job_id, frameJob.frameIndex, frameJob.time);
+            if (!accepted) {
+                // The worker never got the frame, so no JobCompleted will
+                // ever arrive for it — undo the registration and retry the
+                // frame elsewhere.
+                {
+                    std::lock_guard<std::mutex> mapLock(job_map_mutex_);
+                    worker_job_to_render_id_.erase(job_id);
+                }
                 {
                     std::lock_guard<std::mutex> qlock(queue_mutex_);
-                    pending_jobs_.push(job);
+                    pending_jobs_.push(frameJob);
                 }
                 {
                     std::lock_guard<std::mutex> wlock(workers_mutex_);
                     Worker* w = findWorkerByID(worker_id);
                     if (w) w->status = WorkerStatus::OFFLINE;
                 }
-            } else {
-                {
-                    std::lock_guard<std::mutex> mapLock(job_map_mutex_);
-                    worker_job_to_render_id_[job_id] = render_id;
-                }
-
-                // Handle out-of-order completion notifications by finalizing here too.
-                markRenderCompleted(job_id);
+                job_available_.notify_all();
             }
+            // On success, completion (and flipping the worker back to IDLE)
+            // is driven entirely by the worker's JobCompleted RPC.
         });
     }
+}
+
+std::string Scheduler::generateJobId() {
+    std::lock_guard<std::mutex> lock(job_id_gen_mutex_);
+    return boost::uuids::to_string(job_id_gen_());
 }
 
 Worker* Scheduler::findIdleWorker() {

--- a/scheduler/src/scheduler.hpp
+++ b/scheduler/src/scheduler.hpp
@@ -8,13 +8,39 @@
 #include <atomic>
 #include <string>
 #include <iostream>
+#include <optional>
 #include <unordered_map>
 
+#include <boost/uuid/random_generator.hpp>
 #include <grpcpp/grpcpp.h>
 
 #include "worker.hpp"
 #include "renderRequest.hpp"
 #include "render_client.hpp"
+
+// A single frame of an animation, dispatchable to any idle worker
+// independently of the rest of the animation's frames.
+struct FrameJob {
+    std::shared_ptr<RenderRequest> renderRequest;
+    uint32_t frameIndex;
+    float time;
+};
+
+// What a dispatched worker job id refers back to: which render, and which
+// frame of it.
+struct FrameJobContext {
+    std::string renderId;
+    uint32_t frameIndex;
+};
+
+// Tracks how many of a render's frames have landed and their output links,
+// so the parent RenderRequest can be flipped to COMPLETED only once every
+// frame is in.
+struct RenderProgress {
+    uint32_t totalFrames = 0;
+    uint32_t framesCompleted = 0;
+    std::vector<std::optional<std::string>> frameLinks;
+};
 
 class Scheduler {
 public:
@@ -28,7 +54,7 @@ public:
 
 	Worker* findWorkerByID(const std::string& id);
 
-    // Adds job to queue
+    // Splits the render into one FrameJob per animation frame and queues them.
     void addJob(std::shared_ptr<RenderRequest> job);
 
     // Worker list management
@@ -44,10 +70,10 @@ public:
 private:
 	// Constructor and destructor
 	Scheduler() : running_(false) {}
-    ~Scheduler() { stop(); }  
+    ~Scheduler() { stop(); }
 
     // Job queue
-    std::queue<std::shared_ptr<RenderRequest>> pending_jobs_;
+    std::queue<FrameJob> pending_jobs_;
     std::mutex queue_mutex_;
     std::condition_variable job_available_;
 
@@ -55,9 +81,19 @@ private:
     std::vector<Worker> workers_;
     std::mutex workers_mutex_;
 
-    // Tracks worker generated job IDs to scheduler render IDs.
-    std::unordered_map<std::string, std::string> worker_job_to_render_id_;
+    // Tracks scheduler-assigned job IDs back to the render/frame they belong
+    // to. Entries are added before dispatch so a JobCompleted callback can
+    // never arrive before its entry exists.
+    std::unordered_map<std::string, FrameJobContext> worker_job_to_render_id_;
     std::mutex job_map_mutex_;
+
+    // Per-render frame completion tracking, keyed by render id.
+    std::unordered_map<std::string, RenderProgress> render_progress_;
+    std::mutex progress_mutex_;
+
+    // Mints scheduler-assigned job ids.
+    boost::uuids::random_generator job_id_gen_;
+    std::mutex job_id_gen_mutex_;
 
     // Dispatch thread tracking
     std::vector<std::thread> dispatch_threads_;
@@ -70,4 +106,5 @@ private:
     void assignJobs();
     void joinThreads();
     Worker* findIdleWorker();
+    std::string generateJobId();
 };


### PR DESCRIPTION
## Summary

The scheduler didn't do any real scheduling: an entire animation request was
dispatched as a single gRPC `RenderJob` call, with the frame count mistakenly
sent as the animation *time* — so every render produced exactly one (wrong)
frame instead of a collection of frames. Completion tracking also only
"worked" via a race-driven workaround rather than the real completion path.

- Scheduler now splits a `RenderRequest` into one `FrameJob` per animation
  frame at admission time and queues them independently, so each idle
  worker is handed a single frame and picks up the next one from the queue
  when it finishes (`Scheduler::addJob` / `assignJobs`).
- Job ids are minted by the scheduler and registered *before* dispatch
  (`RenderJobRequest.job_id`), which removes the completion race: the
  worker's `RenderJob` handler is synchronous and calls back with
  `JobCompleted` before its own RPC response returns, so the old
  worker-generated-id scheme always lost that race and needed a redundant
  premature completion call to compensate. That workaround is gone.
- Per-render progress (frames completed, one download link per frame index)
  is tracked until every frame lands, then the request flips to `COMPLETED`
  with the full collection (`RenderRequest::downloadLinks`, exposed as
  `download_links` in the status JSON; `download_link` is kept populated
  with frame 0 for backward compatibility with the current frontend).
- Worker uploads are now named by `frame_index` instead of a
  float-formatted time, so output ordering is deterministic.

## Test plan

- [x] `cmake --preset scheduler && cmake --build build-scheduler` — builds clean, zero errors/warnings.
- [x] `cmake --preset render-worker && cmake --build build-render-worker` — builds clean, zero errors/warnings.
- [ ] End-to-end run against a live worker (needs GPU/Vulkan + S3 credentials, not available in this environment).

Note: this repo has no GitHub Actions workflows configured yet, so there
were no CI checks to wait on for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)